### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/chat-bot/template.yaml
+++ b/chat-bot/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: ./bot
       Handler: bot.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 60
       Environment:
         Variables:
@@ -107,7 +107,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource: !Sub "${BotFunction.Arn}:*"
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       DeploymentPreference:
         Enabled: false
         Role: ""

--- a/trivia-backend/infra/codedeploy-blue-green/hooks/template.yaml
+++ b/trivia-backend/infra/codedeploy-blue-green/hooks/template.yaml
@@ -31,7 +31,7 @@ Resources:
               - "codedeploy:PutLifecycleEventHookExecutionStatus"
             Resource:
               !Sub 'arn:${AWS::Partition}:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup:AppECS-*/DgpECS-*'
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       DeploymentPreference:
         Enabled: false
         Role: ""


### PR DESCRIPTION
CloudFormation templates in aws-reinvent-2019-trivia-game have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.