### PR TITLE
Example trivia backend support for EKS on Fargate

### DIFF
--- a/trivia-backend/infra/cdk/eks-service.ts
+++ b/trivia-backend/infra/cdk/eks-service.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import * as cdk from '@aws-cdk/core';
+import {Vpc} from '@aws-cdk/aws-ec2';
+import {Repository} from '@aws-cdk/aws-ecr';
+import {FargateCluster} from '@aws-cdk/aws-eks';
+import {ContainerImage} from '@aws-cdk/aws-ecs';
+import {AccountRootPrincipal, Role} from '@aws-cdk/aws-iam';
+import {ReinventTriviaResource} from './eks/kubernetes-resources/reinvent-trivia';
+
+interface TriviaBackendStackProps extends cdk.StackProps {
+  domainName: string;
+  domainZone: string;
+}
+
+class TriviaBackendStack extends cdk.Stack {
+  constructor(parent: cdk.App, name: string, props: TriviaBackendStackProps) {
+    super(parent, name, props);
+
+    // Network infrastructure
+    const vpc = new Vpc(this, 'VPC', {maxAzs: 2});
+
+    // Initial creation of the cluster
+    const cluster = new FargateCluster(this, 'FargateCluster', {
+      clusterName: props.domainName.replace(/\./g, '-'),
+      defaultProfile: {
+        fargateProfileName: 'reinvent-trivia',
+        selectors: [
+          {namespace: 'default'},
+          {namespace: 'kube-system'},
+          {namespace: 'reinvent-trivia'},
+        ],
+        subnetSelection: {subnets: vpc.privateSubnets},
+        vpc
+      },
+      mastersRole: new Role(this, 'ClusterAdminRole', {
+        assumedBy: new AccountRootPrincipal(),
+      }),
+      outputClusterName: true,
+      outputConfigCommand: true,
+      outputMastersRoleArn: true,
+      vpc,
+    });
+
+    // Configuration parameters
+    const imageRepo = Repository.fromRepositoryName(this, 'Repo', 'reinvent-trivia-backend');
+    const tag = (process.env.IMAGE_TAG) ? process.env.IMAGE_TAG : 'latest';
+    const image = ContainerImage.fromEcrRepository(imageRepo, tag)
+
+    // Kubernetes resources for the ReinventTrivia namespace, deployment, service, etc.
+    new ReinventTriviaResource(this, 'ReinventTrivia', {cluster, image, domainName: props.domainName})
+  }
+}
+
+const app = new cdk.App();
+new TriviaBackendStack(app, 'TriviaBackendProd', {
+  domainName: 'api.reinvent-trivia.com',
+  domainZone: 'reinvent-trivia.com',
+  env: {account: process.env['CDK_DEFAULT_ACCOUNT'], region: 'us-east-1'},
+});
+app.synth();

--- a/trivia-backend/infra/cdk/eks/alb-ingress-controller-policy.ts
+++ b/trivia-backend/infra/cdk/eks/alb-ingress-controller-policy.ts
@@ -1,0 +1,113 @@
+import {Construct} from '@aws-cdk/core';
+import {Effect, ManagedPolicy, PolicyStatement} from '@aws-cdk/aws-iam';
+
+/**
+ * From: https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/iam-policy.json
+ */
+export class AlbIngressControllerPolicy extends ManagedPolicy {
+  constructor(parent: Construct, id: string) {
+    super(parent, id, {
+      managedPolicyName: 'AlbIngressControllerPolicy',
+      description: 'Used by the ALB Ingress Controller pod to make AWS API calls',
+      statements: [
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "acm:DescribeCertificate",
+            "acm:ListCertificates",
+            "acm:GetCertificate"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateTags",
+            "ec2:DeleteTags",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeAddresses",
+            "ec2:DescribeInstances",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeInternetGateways",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeTags",
+            "ec2:DescribeVpcs",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:ModifyNetworkInterfaceAttribute",
+            "ec2:RevokeSecurityGroupIngress"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "elasticloadbalancing:AddListenerCertificates",
+            "elasticloadbalancing:AddTags",
+            "elasticloadbalancing:CreateListener",
+            "elasticloadbalancing:CreateLoadBalancer",
+            "elasticloadbalancing:CreateRule",
+            "elasticloadbalancing:CreateTargetGroup",
+            "elasticloadbalancing:DeleteListener",
+            "elasticloadbalancing:DeleteLoadBalancer",
+            "elasticloadbalancing:DeleteRule",
+            "elasticloadbalancing:DeleteTargetGroup",
+            "elasticloadbalancing:DeregisterTargets",
+            "elasticloadbalancing:DescribeListenerCertificates",
+            "elasticloadbalancing:DescribeListeners",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeLoadBalancerAttributes",
+            "elasticloadbalancing:DescribeRules",
+            "elasticloadbalancing:DescribeSSLPolicies",
+            "elasticloadbalancing:DescribeTags",
+            "elasticloadbalancing:DescribeTargetGroups",
+            "elasticloadbalancing:DescribeTargetGroupAttributes",
+            "elasticloadbalancing:DescribeTargetHealth",
+            "elasticloadbalancing:ModifyListener",
+            "elasticloadbalancing:ModifyLoadBalancerAttributes",
+            "elasticloadbalancing:ModifyRule",
+            "elasticloadbalancing:ModifyTargetGroup",
+            "elasticloadbalancing:ModifyTargetGroupAttributes",
+            "elasticloadbalancing:RegisterTargets",
+            "elasticloadbalancing:RemoveListenerCertificates",
+            "elasticloadbalancing:RemoveTags",
+            "elasticloadbalancing:SetIpAddressType",
+            "elasticloadbalancing:SetSecurityGroups",
+            "elasticloadbalancing:SetSubnets",
+            "elasticloadbalancing:SetWebACL"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "iam:CreateServiceLinkedRole",
+            "iam:GetServerCertificate",
+            "iam:ListServerCertificates"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "cognito-idp:DescribeUserPoolClient"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "waf-regional:GetWebACLForResource",
+            "waf-regional:GetWebACL",
+            "waf-regional:AssociateWebACL",
+            "waf-regional:DisassociateWebACL"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "tag:GetResources",
+            "tag:TagResources"
+          ]
+        }),
+        new PolicyStatement({
+          resources: ['*'], effect: Effect.ALLOW, actions: [
+            "waf:GetWebACL"
+          ]
+        })
+      ]
+    })
+  }
+}

--- a/trivia-backend/infra/cdk/eks/kubernetes-resources/reinvent-trivia.ts
+++ b/trivia-backend/infra/cdk/eks/kubernetes-resources/reinvent-trivia.ts
@@ -1,0 +1,115 @@
+import {Construct} from '@aws-cdk/core';
+import {Cluster, KubernetesResource} from '@aws-cdk/aws-eks';
+import {EcrImage} from '@aws-cdk/aws-ecs';
+/**
+ * Properties for ReinventTriviaResources
+ */
+export interface ReinventTriviaResourceProps {
+  /**
+   * The EKS cluster to apply this configuration to.
+   */
+  readonly cluster: Cluster;
+
+  /**
+   * The domain name to use for the API.
+   */
+  readonly domainName: string;
+
+  /**
+   * Reference to the existing container image from ECR.
+   */
+  readonly image: EcrImage;
+}
+
+export class ReinventTriviaResource extends KubernetesResource {
+  constructor(parent: Construct, id: string, props: ReinventTriviaResourceProps) {
+    const manifest = [
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "reinvent-trivia"
+        }
+      },
+      {
+        "apiVersion": "extensions/v1beta1",
+        "kind": "Deployment",
+        "metadata": {
+          "name": "api",
+          "namespace": "reinvent-trivia"
+        },
+        "spec": {
+          "replicas": 1,
+          "template": {
+            "metadata": {
+              "labels": {
+                "app": "api"
+              }
+            },
+            "spec": {
+              "containers": [
+                {
+                  "image": props.image.imageName,
+                  "imagePullPolicy": "Always",
+                  "name": "api",
+                  "resources": {
+                    "requests": {
+                      "cpu": "375m",
+                      "memory": "1536Mi"
+                    }
+                  },
+                  "ports": [
+                    {
+                      "containerPort": 80
+                    }
+                  ],
+                  "env": [
+                    {
+                      "name": "KUBE_NODE_NAME",
+                      "valueFrom": {
+                        "fieldRef": {
+                          "fieldPath": "spec.nodeName"
+                        }
+                      }
+                    },
+                    {
+                      "name": "KUBE_POD_NAME",
+                      "valueFrom": {
+                        "fieldRef": {
+                          "fieldPath": "metadata.name"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+          "name": "api",
+          "namespace": "reinvent-trivia",
+        },
+        "spec": {
+          "ports": [
+            {
+              "port": 80,
+              "targetPort": 80,
+              "protocol": "TCP"
+            }
+          ],
+          "type": "NodePort",
+          "selector": {
+            "app": "api"
+          }
+        }
+      }
+    ]
+
+    super(parent, id, {cluster: props.cluster, manifest})
+  }
+}

--- a/trivia-backend/infra/cdk/package-lock.json
+++ b/trivia-backend/infra/cdk/package-lock.json
@@ -5,12 +5,12 @@
     "requires": true,
     "dependencies": {
         "@aws-cdk/assets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.15.0.tgz",
-            "integrity": "sha512-zQGaQxlIt+ddWIxeLRFhInC3XiJ73jv84uLXp5R7X3+86q6LZzw9BeFjMTwigt/5UFYMprt3JvVP71fJ3tmEbA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.24.0.tgz",
+            "integrity": "sha512-ryzgvumqlurQq+8l5GPMMtxzRQkAgiZ2Al+FwKT+7JHIgHh0Ed+FuHyjL2e/BVR/utaNQv4eFHGF0wIO5VBiug==",
             "requires": {
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0",
                 "minimatch": "^3.0.4"
             },
             "dependencies": {
@@ -40,466 +40,541 @@
             }
         },
         "@aws-cdk/aws-apigateway": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.15.0.tgz",
-            "integrity": "sha512-KP88hEHYwnQ8inI6Nr8j4yv8PHXl5K1B50bZHF69ESaLhRd57T7OelSKSLZOQPMEZgmgT9blaqKAO1/47jABpQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.24.0.tgz",
+            "integrity": "sha512-mjm4zeOUdznOIgBUneTb0wvs55SDEGH6YqhJNTGFqD6fr4sWb8jNFFvzA8WvYBSoBXFTjeQw+3xGfVvBWP1R5g==",
             "requires": {
-                "@aws-cdk/aws-certificatemanager": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-certificatemanager": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-applicationautoscaling": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.15.0.tgz",
-            "integrity": "sha512-4fs0CN+4RDBxRe9wEoaYTUanHo4Zck8NoWhC35cDsaajh5FFzbplA10hfyhLUA6Tr/827KcTF/JHPerxpved4A==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.24.0.tgz",
+            "integrity": "sha512-UHdSR6XwV+yf5nqfMoiCQgPzuX/lO1NFgz2Gdala/XXYQRRPVHe85ASBwKJXYqIvGXQNrr/5kALrIDwQ07bZ/A==",
             "requires": {
-                "@aws-cdk/aws-autoscaling-common": "1.15.0",
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-autoscaling-common": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-autoscaling": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.15.0.tgz",
-            "integrity": "sha512-+TTjf2GL+2uT4Q7eHp1BmiyVdyBGZKptjLT6cTwwLYL0uYiAItkYyQVaWTIbJtSXFgERadlxRsbCQgZOefR50A==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.24.0.tgz",
+            "integrity": "sha512-qtpZKY+NtXScz1v1FoKpBlvHyLrmtxQpxON0SkR+/tVTANI4/1+MEFXeKbr99jKwPq6/GlVNOJtZyLBRmphmyg==",
             "requires": {
-                "@aws-cdk/aws-autoscaling-common": "1.15.0",
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancing": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-autoscaling-common": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancing": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-autoscaling-common": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.15.0.tgz",
-            "integrity": "sha512-jN24sqqFBCibf+NlA69iE1+WdpXyHByKwqWKAVG4d31Bk5VvUSbKUlhXTknKo3wrxH0igttatWP7U0UpzMzKaA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.24.0.tgz",
+            "integrity": "sha512-dQjq8jA0kTapaxg078KDI7oQKy4Af204DETndrV90nyNqkG+yr38H7GnuQI2TgRk7m60WVX64a9bGpRRUN9gnQ==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-autoscaling-hooktargets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.15.0.tgz",
-            "integrity": "sha512-J31eSCZeinTcTiSm1DmXsIBpf5GNeXPXDqUpB0nCSee29VpVtrKxLfBCWRqCEFoDK8NajPw2PSOh1d6N3k57wA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.24.0.tgz",
+            "integrity": "sha512-DIgnR4Ma2yQMLfZxSajXSfewcIWTuys4mlGa8yvcccelQ6IX85wUz64hsC3z+gx70blStNSVMIGCViQ83Zor9A==",
             "requires": {
-                "@aws-cdk/aws-autoscaling": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/aws-sns-subscriptions": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-autoscaling": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-sns-subscriptions": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-certificatemanager": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.15.0.tgz",
-            "integrity": "sha512-gF+8MnwnyMEczsBfqibSLPu3ab9aukThI1CZ3zbPrDqjjyMbWKuRrpjDOev4wdqDPSs0ujk/Kw1rKB1Z+zrUkA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.24.0.tgz",
+            "integrity": "sha512-D7JUZ2IKCSYsGj1rocn0CF/WyJJeleVeRfojSFchH9Iw8cqaN5ejYzXKdOrtGOtvyjrLFnjlly7+sL9xIXXpxA==",
             "requires": {
-                "@aws-cdk/aws-cloudformation": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-route53": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-route53": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-cloudformation": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.15.0.tgz",
-            "integrity": "sha512-GOGQleKJ1Iw5LIqLlAY2Hq2zhKJj3De+exVztXHg++74euxegV7GwGkJS/xuWzbM0ditVbGXdDC664MFAXrWzw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.24.0.tgz",
+            "integrity": "sha512-zBI8W9n+s16jx5dMP6GdAKYeeEsUOIuX4Y8yiTaVYh+C2Gezi4gVwcd+2oHQ+s3YBUilArYMaTx4yEnCHNUq9Q==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-cloudfront": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.15.0.tgz",
-            "integrity": "sha512-jAtrBBdZ0eUq735XyAR77cafWHEnrJFbWE68OM0BQH4L9dQn3alX5Wu92Zsk9fW2TNiu3OSKZNr1RQpWQSV7fg==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.24.0.tgz",
+            "integrity": "sha512-5s+7dVyndQ7eMyulHZVMgZcXITvVNJZUKet7SESSjSaz6KvtBGCv8WN5USfnRrMx6bCGTjoLlNH3RvEL3xEetg==",
             "requires": {
-                "@aws-cdk/aws-certificatemanager": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-certificatemanager": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-cloudwatch": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.15.0.tgz",
-            "integrity": "sha512-bYGCVP6479dnUOOJxxDzVzc6uzyNIHxsbF8zormEJeP0oLS/IF8+cReOM9nPhBdeAsAYgKkusRY+dRleC+tEbw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.24.0.tgz",
+            "integrity": "sha512-cK4HrIYYuxRiAVwNKZdQwaCG/5QKN2T/VnaB4GMZCeLU1RdgO4mvBHCV9QkkIYjSXvk+X1T1hHqg48GKfyMT5g==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-codebuild": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.15.0.tgz",
-            "integrity": "sha512-K5jEIPiipeYm5OLKjWH2r5OCq8hajkrFy2wg1ZZMyZZyKmcu7sx79f32BgVyxB6tOb5EKyqDpodv6YQPN4qUIg==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.24.0.tgz",
+            "integrity": "sha512-3WxaNwdgdYbJ8N0wHAA7a5/BoRLJQWTykz/fRVVro2WAWnY2lexgSujimS4nx55Kh5GkDVqPmyntlg4X/TROQQ==",
             "requires": {
-                "@aws-cdk/assets": "1.15.0",
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-codecommit": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-ecr": "1.15.0",
-                "@aws-cdk/aws-ecr-assets": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/aws-s3-assets": "1.15.0",
-                "@aws-cdk/aws-secretsmanager": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/assets": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-codecommit": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-ecr": "1.24.0",
+                "@aws-cdk/aws-ecr-assets": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/aws-s3-assets": "1.24.0",
+                "@aws-cdk/aws-secretsmanager": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-codecommit": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.15.0.tgz",
-            "integrity": "sha512-MH0iEJqhGh0IqQTkhnQI+RlJfPw73RabygR7h4EPOa/24BZ4Img+AR+ynTEjVVXtjC432iCgwGTwi54zy004Lw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.24.0.tgz",
+            "integrity": "sha512-SEdfa0VChVfHqfmR/2IgVFPGNUrDAkyT8E5fH+6NMIGQPnOLbl8ZthQi7SuPEw0Gm4imTcnFxIPZoltNr9Ue0w==",
             "requires": {
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-codepipeline": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.15.0.tgz",
-            "integrity": "sha512-Bj4bNCP9mxrtf+deZLB/BBb98n93phxUx/Kj3NHNFuexSvzZIyNeX0x8X68NwP+xZYHszIL4AArVElY9+YvYnw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.24.0.tgz",
+            "integrity": "sha512-vZ+ELEIY/bAKn5gLGoEl+uTqp92BJbol89ySCC+WR0x/XDba4A6y9Q7YXdkCf6geHLFYym3xHXgGc0uVh9myXA==",
             "requires": {
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-ec2": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.15.0.tgz",
-            "integrity": "sha512-o729HqLXtVA/mUUg/76q2HaBG4AczGSZMZO+x/ksSO1UnJLmWpdbNjCScaId/R6ip8YX7Gy969PytP8xIOayPA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.24.0.tgz",
+            "integrity": "sha512-FIzsbJOBCT1mXrRZuUn701my2DDkL0y5HQ7n6LeTmXtHtGbNgfqHD/P2T5jj7UIXIOZLdMEeUIgujt4/j6UtwA==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-ssm": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-logs": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/aws-ssm": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-ecr": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.15.0.tgz",
-            "integrity": "sha512-BVtVVijN4j9m1HTFBR0BVWBlKtRoZsLXPbBWuTegSH8v+ROmyDErkGHMEy3LzhrHzdRDjw36oWcvqkZyI6TqPw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.24.0.tgz",
+            "integrity": "sha512-R5y8lHWbjJ/Cd3z+RkIQoAiQlfqo27XdNQOWLcdEpW2jsnPAy9VFUPwhcSSN43apJ6IHnaw56L6WRsvdYesErQ==",
             "requires": {
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-ecr-assets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.15.0.tgz",
-            "integrity": "sha512-X1YWleWLIIGwJFSoawKhYPI4aruiJ727lkzf2xwGBythiTQUS8m5aWk99FLWrnaNJ1lJY68M+Hu9+4QjlE/tzQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.24.0.tgz",
+            "integrity": "sha512-4HvC96uHAbXwZYl1KARvdZYNYvretKcKnEx10zmL4K5J6dny8/4oxo88DOJsegRyBGD6FPsoAvIYoyIwi+KGbw==",
             "requires": {
-                "@aws-cdk/assets": "1.15.0",
-                "@aws-cdk/aws-cloudformation": "1.15.0",
-                "@aws-cdk/aws-ecr": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/assets": "1.24.0",
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-ecr": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
             }
         },
         "@aws-cdk/aws-ecs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.15.0.tgz",
-            "integrity": "sha512-qfLWEcBTcN3BOAkV7QARhOP06XBlwu/r83S6DIhHSeAiW7JxLrSmuof4NDwh35DMWiv2KGF9r2Vx5HBrfW3RqA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.24.0.tgz",
+            "integrity": "sha512-P9nNZ9u2TMwUGzSlv2yHVuzgMoiBUJw5L2BWiesMfbD4/JTAzs9fOViY+ZL7WDEoC7DrpxFEVrrSi0159tJ/rQ==",
             "requires": {
-                "@aws-cdk/aws-applicationautoscaling": "1.15.0",
-                "@aws-cdk/aws-autoscaling": "1.15.0",
-                "@aws-cdk/aws-autoscaling-hooktargets": "1.15.0",
-                "@aws-cdk/aws-certificatemanager": "1.15.0",
-                "@aws-cdk/aws-cloudformation": "1.15.0",
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-ecr": "1.15.0",
-                "@aws-cdk/aws-ecr-assets": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancing": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-logs": "1.15.0",
-                "@aws-cdk/aws-route53": "1.15.0",
-                "@aws-cdk/aws-route53-targets": "1.15.0",
-                "@aws-cdk/aws-secretsmanager": "1.15.0",
-                "@aws-cdk/aws-servicediscovery": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/aws-ssm": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-applicationautoscaling": "1.24.0",
+                "@aws-cdk/aws-autoscaling": "1.24.0",
+                "@aws-cdk/aws-autoscaling-hooktargets": "1.24.0",
+                "@aws-cdk/aws-certificatemanager": "1.24.0",
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-ecr": "1.24.0",
+                "@aws-cdk/aws-ecr-assets": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancing": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-logs": "1.24.0",
+                "@aws-cdk/aws-route53": "1.24.0",
+                "@aws-cdk/aws-route53-targets": "1.24.0",
+                "@aws-cdk/aws-secretsmanager": "1.24.0",
+                "@aws-cdk/aws-servicediscovery": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/aws-ssm": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-ecs-patterns": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs-patterns/-/aws-ecs-patterns-1.15.0.tgz",
-            "integrity": "sha512-KJp+X8QTqNktzHYyfqj81jY4qo94WSJuPyFs80SgvOSkk8PPcPatcuy2XlDBmhwiGzK04Crg5PLVvd+j0am5fA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs-patterns/-/aws-ecs-patterns-1.24.0.tgz",
+            "integrity": "sha512-FhNLWgrXbI/VrEKxgN2TATfyBc/NK7YMLyEgLklIanEvU98EqWz6gDwfgqJm3hjCLrSQ204piM2YUVCzCvshiQ==",
             "requires": {
-                "@aws-cdk/aws-applicationautoscaling": "1.15.0",
-                "@aws-cdk/aws-certificatemanager": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-ecs": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-events-targets": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-route53": "1.15.0",
-                "@aws-cdk/aws-route53-targets": "1.15.0",
-                "@aws-cdk/aws-servicediscovery": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-applicationautoscaling": "1.24.0",
+                "@aws-cdk/aws-certificatemanager": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-ecs": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-events-targets": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-route53": "1.24.0",
+                "@aws-cdk/aws-route53-targets": "1.24.0",
+                "@aws-cdk/aws-servicediscovery": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
+            }
+        },
+        "@aws-cdk/aws-eks": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-eks/-/aws-eks-1.24.0.tgz",
+            "integrity": "sha512-rhsV14E3E6C5NGtBZF3U8qN6m6q+DuqMPkwIM6e7BTG1k3cm7rL4etM/SQy4Cyl/u8REcZ/FmDSq/y3l8gEZjw==",
+            "requires": {
+                "@aws-cdk/aws-autoscaling": "1.24.0",
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-ssm": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/custom-resources": "1.24.0"
             }
         },
         "@aws-cdk/aws-elasticloadbalancing": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.15.0.tgz",
-            "integrity": "sha512-oH1NHCaKlsChrwF6jJ0YJ8gax47dSvMe/gpiuR/NiW9pdrAECjlgsGSmqiDS7FiBLLRmZoKIhJpa/ajfdl1B9A==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.24.0.tgz",
+            "integrity": "sha512-BZcGyEkDFunULwHgsSlLN7cZ/YfwpGzMlpbsRd+N9dX5pAKz0kJQfK+L8QqhGB3oT9dDCKw9nFOwIUJDYL1SNQ==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-elasticloadbalancingv2": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.15.0.tgz",
-            "integrity": "sha512-MakvmnhVDZS0rlCOvbWZ6CyfEySVVQbquy9rv4/p/ywEdTQ8RQWTJQ7hynplFt6Kbi4J3oz91iC4eUgSMERWtw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.24.0.tgz",
+            "integrity": "sha512-jh8tmWkdMBy/BYMpcwZX9D+G1X7t6MWWWAWv0X8kzB1hYXw2yGS7jzcf7gPRGuf3IKQVJtUjp86sd8uSn6WcGA==",
             "requires": {
-                "@aws-cdk/aws-certificatemanager": "1.15.0",
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-certificatemanager": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-events": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.15.0.tgz",
-            "integrity": "sha512-kkPn4PdgniSMED/1YTimVhAw5KIZfwbHS1CFtxPxAHtHVN8vQ0ewHgVlfZGaP9O96FpWkW+kuyc40Hfz8LES9g==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.24.0.tgz",
+            "integrity": "sha512-/GkZXyGJ/8qzuGElhEa3PbCE2QsjyjvAxRey/ICDM3lIqBj3SWUm3RPT43emLT45AqRt/+ATcXORFwo9FIw9QA==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-events-targets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.15.0.tgz",
-            "integrity": "sha512-lJoNLr0PKIScwm1c/UC/RAwZfUEMwmsF9AHhdyH3l/EqrPwE25sOVoBbKa8FGiQJfzWcONxgYUIMQEcCa5QGKw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.24.0.tgz",
+            "integrity": "sha512-CM7MyjWgwSIznRkO4OMzeUEb0XJKgOJa5Tk/8MeFcta+V7dJPWP1yMtmON8ei/02jt1/fFjYycBBS4Ifu8MvDQ==",
             "requires": {
-                "@aws-cdk/aws-cloudformation": "1.15.0",
-                "@aws-cdk/aws-codebuild": "1.15.0",
-                "@aws-cdk/aws-codepipeline": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-ecs": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/aws-sns-subscriptions": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/aws-stepfunctions": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-codebuild": "1.24.0",
+                "@aws-cdk/aws-codepipeline": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-ecs": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-sns-subscriptions": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/aws-stepfunctions": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-iam": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.15.0.tgz",
-            "integrity": "sha512-zOPMe7G2Fq/vKI4c9ip09L7v0gtVtrfO9i9nBH6l/Nt+K09N08GsavPAPQCgVaYdN6KRhGvEBTwnsBtGw2300A==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.24.0.tgz",
+            "integrity": "sha512-M+0CeKRr6aQbppyjWNuBDmFS6VSimA3Y3nonKwtLUFBGk656t743cW2q+KxwB98c3iPTcGVcyUJ08VoNC3V29w==",
             "requires": {
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/region-info": "1.15.0"
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/region-info": "1.24.0"
             }
         },
         "@aws-cdk/aws-kms": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.15.0.tgz",
-            "integrity": "sha512-UOsxCEmUAa9t/Vt2OKmPV7gGyBODpAn/6pYIhBVgL7E8kVXxuL6VqeCVdMPDiAga3a5sR8HQypzLcxg1WOIObw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.24.0.tgz",
+            "integrity": "sha512-fN31SXEhulqjotCpYorjRk0A5apOSGSeqhn8LN0mHtsnUl9oaiYpjJ67q1BTy+U+ai0hF6moQLau2/2gdmWcGg==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-lambda": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.15.0.tgz",
-            "integrity": "sha512-XGMN+6jzB2V4JPi3znmXMmclgMgYibwYU1kxTGXhfbGngCu7TcNGWoEhlZGTu20tWKqUOLaf3XPOzfBrnmc12g==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.24.0.tgz",
+            "integrity": "sha512-/PCFBvGWTQPFkEaUc7upSN6dOVKLSO6GoytfUOagLtMEnRbFwJyKjR5xY66q2nJdIRq7Rsv7d7TzPjR6N+YBOQ==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-logs": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/aws-s3-assets": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-logs": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/aws-s3-assets": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-logs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.15.0.tgz",
-            "integrity": "sha512-TTTMU+Qo0VHlilaEW0+Vk28HZUx6naSJrzj9yYYLP+HIjBCROpPpNI3N0p/8rYGDCEGmTrv4XBbOjcvV0EDB8Q==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.24.0.tgz",
+            "integrity": "sha512-AZGUQuNXQ9oYGnpaa5p0QUUbHg+L0y5+Ose7dFZ2FZqdFLPjEyEl3EiYTgHKQZ8aRcAOZV+v+lVS8ETb7XvNQA==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-route53": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.15.0.tgz",
-            "integrity": "sha512-dFcIKb28+aT3n5DOGUrwa6gMxKzHWtpUQcK4O7Or1OyxRoHCj6eUDdERT5lv/UZ7zRTL3UnPuC5rOYk0b0Ra1A==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.24.0.tgz",
+            "integrity": "sha512-fuAMnr2a4+fDI4Ok2U5Nz8ihMk8Fzk5vmpsEu9qHLRpky4tc0gy7K4gsT98X0YREq4Oc8rMuKCsCxwvUaHExUw==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-logs": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-logs": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-route53-targets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.15.0.tgz",
-            "integrity": "sha512-Lgy3wBps/IZBo6BFaN1a64q/HmwqWRNwiAyxOIeGCsJVdTb4Sk7dKKbhm4WGMT8V9Jb/CUDFOOxedYKqxDjY9Q==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.24.0.tgz",
+            "integrity": "sha512-z+1HlDdIWYelWkqcUbE2XOfWrY4I0FFmgvQgUJByIX8odkt6KqhX7K/0xMzqs/+IOoyCcGYG6GwQ9yudmL0uqw==",
             "requires": {
-                "@aws-cdk/aws-apigateway": "1.15.0",
-                "@aws-cdk/aws-cloudfront": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancing": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-route53": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/region-info": "1.15.0"
+                "@aws-cdk/aws-apigateway": "1.24.0",
+                "@aws-cdk/aws-cloudfront": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancing": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-route53": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/region-info": "1.24.0"
             }
         },
         "@aws-cdk/aws-s3": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.15.0.tgz",
-            "integrity": "sha512-4mMdRqJkY8rtcs0J2Y7dCunYFV79f0wZ2rgVlW3qS+mExLgTjoUwysajwwOvzGKG0rBp27DPCCW2f/t7l65FuA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.24.0.tgz",
+            "integrity": "sha512-X4CFpE10XVYGQrAR+wolHwdo8N3bqxTlZtwGpWzLsxsGoUXhlasy3zT7pZ+Hlg724VvviRmACZi/JrerIyjvuA==",
             "requires": {
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-s3-assets": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.15.0.tgz",
-            "integrity": "sha512-4Y4egaDXWqzID/jLQaE+udBuTZJpCqvdm9fDJ6yEAzavQkwyO5WiZhQyUXFb2hMcUYUcnDj4D2uDATkVcc52tQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.24.0.tgz",
+            "integrity": "sha512-xe5RmVFk/5E5EmfJ0R1kkzPtKJRVGiEpWAE6MtdYrfmSE+UsDP1PVfodJzNMKsFfVNVd3nLo3AF1y6zLwWQMSw==",
             "requires": {
-                "@aws-cdk/assets": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-s3": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/assets": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
+            }
+        },
+        "@aws-cdk/aws-sam": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.24.0.tgz",
+            "integrity": "sha512-uentW+PCcGIlR09JzZa1WCL2sWvRVt1gXizxkxjTae8ur0lPc22w2U5MDWEt2xi+ZzQZESEnsIRZ9QonP8fMWg==",
+            "requires": {
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-secretsmanager": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.15.0.tgz",
-            "integrity": "sha512-wxaoXRirdtfwoTSKmgKXaVzlXQ311vT5/j4GoWqyzLu+3lRA9jn60nUF1rbX4AKydlKFuoNAOG+z40A1B3xxsQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.24.0.tgz",
+            "integrity": "sha512-02PGcZC3snDOg896zVVHzMF0A0IXHxU1fM8Myrr9SRDg5CQF9BZFLIaWKI2+JJvL/CjoZ40oS6xSlhFAolExbg==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-sam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-servicediscovery": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.15.0.tgz",
-            "integrity": "sha512-UQyw2Q67FWqWArbfRbeweqgjiDD7B5g8lPG8T5LAVDNUIZRBkZ5X2KVSiEUTiq4n4sxMZAKEIxmFp5o6YPLe+w==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.24.0.tgz",
+            "integrity": "sha512-x3+36ynpoJx6ZN35UHjQSpkHdbobU8OGjHX+MVbo6k27EZ8vZSBX6ife2e05pgvBcstRlSAw7gETf9HZnq02wQ==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.15.0",
-                "@aws-cdk/aws-elasticloadbalancingv2": "1.15.0",
-                "@aws-cdk/aws-route53": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-elasticloadbalancingv2": "1.24.0",
+                "@aws-cdk/aws-route53": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-sns": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.15.0.tgz",
-            "integrity": "sha512-9wLLT+zGNmgiii4LvILz6Yvfypg8ozYTdJMPvfonElWJqErz1x6vaSCNNJkWX4hkoLeEmjEscAFbiusqmngjJQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.24.0.tgz",
+            "integrity": "sha512-SHNK2qQggdSBs0Mf5byNCsCHT/6yf8qt+X+5sAhb5DGX3oaQw+P+Ow0f5szhp1gDd6s0GHBeutcozrkGMPO9Sw==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-sns-subscriptions": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.15.0.tgz",
-            "integrity": "sha512-64Ql+ka9+jTY3D5mC4Y3SDfwEbhfYpVDzLe9yORQygcqazgz5mEVZs0TUc9AEvy7gaHkQz3JssnBYZpPdW558w==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.24.0.tgz",
+            "integrity": "sha512-K1OTqZ+IoV1hx3ARO5rzgifa1JVjP/FslDtWcGecMY3drMhufC9FdAzRVZmt3UCbi0K7JxjHGOsY+SUIxII4dQ==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-lambda": "1.15.0",
-                "@aws-cdk/aws-sns": "1.15.0",
-                "@aws-cdk/aws-sqs": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-sqs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.15.0.tgz",
-            "integrity": "sha512-SbUyQgvCSrP/XdeQ7GoUdsoQ+/GvJtpP/fsq7cpiYVRJ6rMgtg3JiwliU8pEJSLqIumffmkuZah+rBKxHlqhxw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.24.0.tgz",
+            "integrity": "sha512-QUh7nnGfEHKKawr3TcpyUATNBDGGunggd+ezXxNcln79w5AuAuUeeEpcNkLWadLXsN/xO/R66do0lYpCwdaIrQ==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/aws-ssm": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.15.0.tgz",
-            "integrity": "sha512-SGTT3B43Bh7EJmIg+vXpOOVWaqaoxP6P3bQtg098tM1I+CnKICZd7bTn2NpZkrZBwAuQT27n7/A9kN7qPA/8lw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.24.0.tgz",
+            "integrity": "sha512-TNLwJ4tbT4ryn6nxn++ESjs6e9wUQlAC6ZVJ2sSDQE0jnGP08Yx87viQ4f+gF14LUi7sOuklp2ud9jXfhi8hyg==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/aws-kms": "1.15.0",
-                "@aws-cdk/core": "1.15.0",
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/core": "1.24.0",
+                "@aws-cdk/cx-api": "1.24.0"
             }
         },
         "@aws-cdk/aws-stepfunctions": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.15.0.tgz",
-            "integrity": "sha512-0RUDphSJpxJLmqj3UiBmdnmK+IwcQpeffmq1eUEQtXyj+yYib9fNxKm9GIFJgUrusZevEphJ4Gn8bDJLToQcaw==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.24.0.tgz",
+            "integrity": "sha512-R4UvWGF0RT1PV6XNp/YtLQnle4TCwOfVp4pSf5xVvHGWsSQjaPNVYjyFjxiS9F09nodOpia/Hf4sEq5EkOcZKQ==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.15.0",
-                "@aws-cdk/aws-events": "1.15.0",
-                "@aws-cdk/aws-iam": "1.15.0",
-                "@aws-cdk/core": "1.15.0"
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-events": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
+            }
+        },
+        "@aws-cdk/aws-stepfunctions-tasks": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.24.0.tgz",
+            "integrity": "sha512-S5OZAtpcH790c7+3RSbXkm3mRv6Leb1AzlxDs5tlUMyQSjHOPtkFyiz/+M3ku7IvAM8fqDxR5X+K7sTuRKxRaw==",
+            "requires": {
+                "@aws-cdk/assets": "1.24.0",
+                "@aws-cdk/aws-cloudwatch": "1.24.0",
+                "@aws-cdk/aws-ec2": "1.24.0",
+                "@aws-cdk/aws-ecr": "1.24.0",
+                "@aws-cdk/aws-ecr-assets": "1.24.0",
+                "@aws-cdk/aws-ecs": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-kms": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-s3": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-sqs": "1.24.0",
+                "@aws-cdk/aws-stepfunctions": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/cfnspec": {
@@ -524,52 +599,48 @@
                 "fast-deep-equal": "^3.1.1",
                 "string-width": "^4.2.0",
                 "table": "^5.4.6"
-            },
-            "dependencies": {
-                "@aws-cdk/cx-api": {
-                    "version": "1.24.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.24.0.tgz",
-                    "integrity": "sha512-+vuGyi7yiGIKjMsvb5iz9B9Ni2YdnqHTcEeQ+pLnFsoVCxR4kxqfdNlZ+ZXA7EPIlc57buDu7NFgGoWwdCegug==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^7.1.2"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "7.1.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                }
             }
         },
         "@aws-cdk/core": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.15.0.tgz",
-            "integrity": "sha512-3AIuxumb+6VAowGpSUc6s84WVJYHV1lVjECJWlvzvQP2ObPKq46HzoUnBoGKEf2IlG3l7zr2q1spFHRO+fmaZQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.24.0.tgz",
+            "integrity": "sha512-MM+gqBxWhmrGGYHkabteTgRZW4vKnDVPGbwFIoKoZX9nMp2IxJ3zEAf0sOFxeYUArmvYVmhDz+8S4yHM6S/7Xg==",
             "requires": {
-                "@aws-cdk/cx-api": "1.15.0"
+                "@aws-cdk/cx-api": "1.24.0"
+            }
+        },
+        "@aws-cdk/custom-resources": {
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.24.0.tgz",
+            "integrity": "sha512-6u0cEY4Y05DHsLcLJ1x1XTDab91IFPU1OGmYHVjLfAtND6pQRYBnBto5EYhfShrW79EmsgLcSWfNaGJG9K/ULw==",
+            "requires": {
+                "@aws-cdk/aws-cloudformation": "1.24.0",
+                "@aws-cdk/aws-iam": "1.24.0",
+                "@aws-cdk/aws-lambda": "1.24.0",
+                "@aws-cdk/aws-sns": "1.24.0",
+                "@aws-cdk/aws-stepfunctions": "1.24.0",
+                "@aws-cdk/aws-stepfunctions-tasks": "1.24.0",
+                "@aws-cdk/core": "1.24.0"
             }
         },
         "@aws-cdk/cx-api": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.15.0.tgz",
-            "integrity": "sha512-VSR+OQ7x/mMiyXgiqREraSGs00v9W/h2jXW1jCIxfcWTBWAEAVvRE5dsR8CHf6NyH/+6pq5YN6rUzEpwyd2UCA==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.24.0.tgz",
+            "integrity": "sha512-+vuGyi7yiGIKjMsvb5iz9B9Ni2YdnqHTcEeQ+pLnFsoVCxR4kxqfdNlZ+ZXA7EPIlc57buDu7NFgGoWwdCegug==",
             "requires": {
-                "semver": "^6.3.0"
+                "semver": "^7.1.2"
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
+                    "version": "7.1.2",
                     "bundled": true
                 }
             }
         },
         "@aws-cdk/region-info": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.15.0.tgz",
-            "integrity": "sha512-mpWoUTbJd80uZ0sPoxdK3W4heyra8nO5Q6FrXtLPjvubCik/wCoLRpkZtb5bJdX/c582o8onscT1OFFAyF/8YA=="
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.24.0.tgz",
+            "integrity": "sha512-J/p0EYPJ6kk4Efs0fnXxdJX4mayGCkD9HLRmv+amoY1wgyKf36JDKueAyRkKj/MvN81lUFkLKRoAA/f0CCtRYA=="
         },
         "@babel/runtime": {
             "version": "7.8.4",
@@ -747,30 +818,6 @@
                 "uuid": "^3.4.0",
                 "yaml": "^1.7.2",
                 "yargs": "^15.0.2"
-            },
-            "dependencies": {
-                "@aws-cdk/cx-api": {
-                    "version": "1.24.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.24.0.tgz",
-                    "integrity": "sha512-+vuGyi7yiGIKjMsvb5iz9B9Ni2YdnqHTcEeQ+pLnFsoVCxR4kxqfdNlZ+ZXA7EPIlc57buDu7NFgGoWwdCegug==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^7.1.2"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "7.1.2",
-                            "bundled": true,
-                            "dev": true
-                        }
-                    }
-                },
-                "@aws-cdk/region-info": {
-                    "version": "1.24.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.24.0.tgz",
-                    "integrity": "sha512-J/p0EYPJ6kk4Efs0fnXxdJX4mayGCkD9HLRmv+amoY1wgyKf36JDKueAyRkKj/MvN81lUFkLKRoAA/f0CCtRYA==",
-                    "dev": true
-                }
             }
         },
         "aws-sdk": {

--- a/trivia-backend/infra/cdk/package.json
+++ b/trivia-backend/infra/cdk/package.json
@@ -16,14 +16,15 @@
         "aws-cdk": "^1.24.0"
     },
     "dependencies": {
-        "@aws-cdk/aws-certificatemanager": "^1.15.0",
-        "@aws-cdk/aws-cloudwatch": "^1.15.0",
-        "@aws-cdk/aws-ec2": "^1.15.0",
-        "@aws-cdk/aws-ecr": "^1.15.0",
-        "@aws-cdk/aws-ecs": "^1.15.0",
-        "@aws-cdk/aws-ecs-patterns": "^1.15.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^1.15.0",
-        "@aws-cdk/aws-route53": "^1.15.0",
-        "@aws-cdk/core": "^1.15.0"
+        "@aws-cdk/aws-certificatemanager": "^1.24.0",
+        "@aws-cdk/aws-cloudwatch": "^1.24.0",
+        "@aws-cdk/aws-ec2": "^1.24.0",
+        "@aws-cdk/aws-ecr": "^1.24.0",
+        "@aws-cdk/aws-ecs": "^1.24.0",
+        "@aws-cdk/aws-ecs-patterns": "^1.24.0",
+        "@aws-cdk/aws-eks": "^1.24.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^1.24.0",
+        "@aws-cdk/aws-route53": "^1.24.0",
+        "@aws-cdk/core": "^1.24.0"
     }
 }

--- a/trivia-backend/infra/cdk/tsconfig.json
+++ b/trivia-backend/infra/cdk/tsconfig.json
@@ -17,6 +17,7 @@
         "inlineSources": true,
         "experimentalDecorators": true,
         "strictPropertyInitialization":false
-    }
+    },
+    "exclude": ["cdk.out"]
 }
 


### PR DESCRIPTION
This PR adds EKS on Fargate as a third method of setting up the Trivia backend API.

In addition to the VPC, Fargate Cluster, and minimal Kubernetes manifest to get some API pods up and running, it includes the following (all of which are installed using the CDK `HelmChart` construct, with the exception of the HPA):

* Load balancing via the AWS ALB Ingress Controller
* Horizontal Pod Autoscaler (+ the required Metrics Server)
* ExternalDNS for keeping Route 53 up to date.

The `README.md` has been updated with instructions, but there are a few caveats with this initial version due to some limitations (for now) of CDK/CFN, which I've detailed below.

**tl;dr**: There's a manual step and a few ~ugly hacks~ _clever workarounds_ to get around some CDK limitations, but they're all documented and likely to be addressed in CDK not too long from now.

Long version:

1. The process of associating an IAM OIDC provider identity to allow the ALB ingress controller and ExternalDNS pods to perform AWS API calls must be done manually using `eksctl`. This means that initial deployment of this backend would need to happen in _two_ phases - the first would set up the VPC, Cluster, the k8s resources specific to re:Invent Trivia, and the Metrics Server chart, and the second `cdk deploy` would handle everything else after the `oidcProvider` argument is provided.

There is a WIP PR (aws/aws-cdk#6062) that should address this, so we can update this down the road in order to reduce this to a single step / phase.

2. I needed to use `.addDependency(...)` explicitly in a few places due to how some resources require both the Fargate Cluster _and_ Fargate Profile to exist before being created. Technically, the Fargate Cluster finishes building before the Fargate Profile can even begin, so these resources would otherwise jump the gun and cause the deploy to fail. That all caused me enough difficulty testing this PR that I now feel obligated to devise a solution within CDK for it, so perhaps we'll be able to remove those workarounds in the future. :)

3. By default, Helm (and therefore the `HelmChart` construct as well) does not wait for all resources in the chart to be 100% ready and running before "finishing" successfully, so even with explicit `.addDependency(...)` set, the remaining resources will begin building before the dependencies are truly done. The problematic one is Metrics Server, which will cause the entire build to fail if another Helm chart gets installed before it has had a minute to let everything start up. I've worked around this by having CDK add the Metrics Server chart during "Phase 1". The time it takes for the user to associate the IAM OIDC provider identity, update the config, and run `cdk deploy` again is plenty enough time for Metrics Server to become stable, which ensures the remaining charts can install successfully. I have an open PR (aws/aws-cdk#6276) that will allow us to tell the `HelmChart` construct to wait for 100% readiness, at which point we can clean up this workaround too.

Happy to address any specific questions on this PR. Thanks!

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
