### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/chat-bot/template.yaml
+++ b/chat-bot/template.yaml
@@ -13,7 +13,7 @@ Resources:
     Properties:
       CodeUri: ./bot
       Handler: bot.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: 60
       Environment:
         Variables:
@@ -109,7 +109,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource: !Sub "${BotFunction.Arn}:*"
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       DeploymentPreference:
         Enabled: false
         Role: ""

--- a/trivia-backend/infra/codedeploy-lifecycle-event-hooks/template.yaml
+++ b/trivia-backend/infra/codedeploy-lifecycle-event-hooks/template.yaml
@@ -32,7 +32,7 @@ Resources:
               - "codedeploy:CreateCloudFormationDeployment"
             Resource:
               !Sub 'arn:${AWS::Partition}:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup:*/*'
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       DeploymentPreference:
         Enabled: false
         Role: ""


### PR DESCRIPTION
CloudFormation templates in aws-reinvent-2019-trivia-game have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.